### PR TITLE
Adds ignore_scope(false) in update_page method to prevent invalid pag…

### DIFF
--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -183,12 +183,14 @@ class Widget < ActiveRecord::Base
 
   # When a block is saved, the associated page must change its modified attribute
   def update_page
-    if self.update_page_denied.blank?
-      if block = self.block
-        block.reload
-        if widget_page = block.page
-          widget_page.reload
-          widget_page.update_modified(true) unless widget_page.is_modified?
+    ignore_scope(false) do
+      if self.update_page_denied.blank?
+        if block = self.block
+          block.reload
+          if widget_page = block.page
+            widget_page.reload
+            widget_page.update_modified(true) unless widget_page.is_modified?
+          end
         end
       end
     end


### PR DESCRIPTION
…e object when saving widget without active scope.

https://trello.com/c/o30Dhcea/686-las-paginas-no-se-marcan-como-despublicadas-con-los-widgets-que-ignoran-el-scope
