### PR TITLE
Update widget name only if is present

### DIFF
--- a/app/controllers/ubiquo/widgets_controller.rb
+++ b/app/controllers/ubiquo/widgets_controller.rb
@@ -97,7 +97,7 @@ class Ubiquo::WidgetsController < UbiquoController
 
   def change_name
     @widget = Widget.find(params[:id])
-    @widget.update_attributes(:name => params[:value])
+    @widget.update_attribute(:name, params[:value]) if params[:value].present?
     respond_to do |format|
       format.js do
         js_response = render_to_string :update do |page|


### PR DESCRIPTION
https://trello.com/c/lJsUBH2W/1015-nombre-de-widget-en-blanco

Se ha actualizado a update_attribute (sin validaciones), para permitir el cambio en el nombre del widget aunque este pueda no ser válido debido a sus opciones, ya que no tiene demasiado sentido impedir el cambio hasta que no esté configurado.

Únicamente cambiará en caso de estar presente, por lo que ya no se podrá poner vacío, de manera que el requisito de presencia del nombre seguirá funcionando, a pesar del cambio del método del update.

PR del cambio en del hash del commit en gara-web: https://github.com/taigabe/gara-web/pull/543